### PR TITLE
Fix README.md MAILER_TEMPLATES_RECOVERY default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,15 +621,16 @@ Default Content (if template is unavailable):
 `MAILER_TEMPLATES_RECOVERY` - `string`
 
 URL path to an email template to use when resetting a password. (e.g. `https://www.example.com/path-to-email-template.html`)
-`SiteURL`, `Email`, and `ConfirmationURL` variables are available.
+`SiteURL`, `Email`, and `ConfirmationURL`, `Token` variables are available.
 
 Default Content (if template is unavailable):
 
 ```html
-<h2>Reset Password</h2>
+<h2>You have been invited</h2>
 
-<p>Follow this link to reset the password for your user:</p>
-<p><a href="{{ .ConfirmationURL }}">Reset Password</a></p>
+<p>You have been invited to create a user on {{ .SiteURL }}. Follow this link to accept the invite:</p>
+<p><a href="{{ .ConfirmationURL }}">Accept the invite</a></p>
+<p>Alternatively, enter the code: {{ .Token }}</p>
 ```
 
 `MAILER_TEMPLATES_MAGIC_LINK` - `string`


### PR DESCRIPTION
I copied the actual template from the code and pasted it here.

A general comment: Setting up supabase auth standalone was an improvable experience. A lot of small issues on the way. There are a lot of small things undocumented e.g. there exists an createUser endpoint which is not in the API spec or in the readme or some env variables are just not properly documented or have small mistakes. It feels like the docs are a 1:1 copy from netlify/gotrue without any improvement. I know this is not your main business objective to improve the standalone experience but would be awesome if you try to keep the docs up to date with your changes.